### PR TITLE
* npm install does not work as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gordonui",
-  "version": "0.6.6.180916",
+  "version": "0.6.6",
   "description": "Quasar Frontend for Gekko Trading Bot",
   "productName": "Gordon UI",
   "cordovaId": "org.cordova.quasar.app",


### PR DESCRIPTION
@H256 
I have followed instructions and I stuck on

C:\Users\olexi\git\gekko-quasar-ui> npm install
npm WARN deprecated undefined@0.1.0: this package has been deprecated
npm WARN Invalid version: "0.6.6.180916"
npm WARN gekko-quasar-ui No description
npm WARN gekko-quasar-ui No repository field.
npm WARN gekko-quasar-ui No README data
npm WARN gekko-quasar-ui No license field.

added 3 packages from 3 contributors and audited 1 package in 4.905s
found 0 vulnerabilities


C:\Users\olexi\git\gekko-quasar-ui>quasar dev

 Dev mode.......... spa
 Quasar theme...... mat
 Quasar CLI........ v0.17.19
 Quasar Framework.. v0.17.16
 Debugging......... enabled

 app:quasar-conf Reading quasar.conf.js +0ms
 app:dev Checking listening address availability (0.0.0.0:8081)... +5ms

NO ADDITIONAL OUTPUT HERE???

So I have noticed that only 3 packages installed, when I have expected more then 3. So I decided to fix 
npm WARN deprecated undefined@0.1.0: this package has been deprecated
npm WARN Invalid version: "0.6.6.180916"

see  my patch that actually helped! I rerun npm install and got several hundreds of packages installed and quasar dev command worked.

